### PR TITLE
Set the encoding to UTF-8 when writing the Sln and VDProj files.

### DIFF
--- a/Vault2GitLib/Processor.cs
+++ b/Vault2GitLib/Processor.cs
@@ -239,7 +239,7 @@ namespace Vault2Git.Lib
             if (beginingLine >0 & endingLine > 0)
             {
                 lines.RemoveRange(beginingLine, endingLine - beginingLine + 1);
-                File.WriteAllLines(filePath, lines.ToArray());
+                File.WriteAllLines(filePath, lines.ToArray(), Encoding.UTF8);
             }
             return Environment.TickCount - ticks;
         }
@@ -282,9 +282,7 @@ namespace Vault2Git.Lib
         {
             var ticks = Environment.TickCount;
             var lines = File.ReadAllLines(filePath).ToList();
-            File.WriteAllLines(filePath, 
-                lines.Where(l => !l.Trim().StartsWith(@"""Scc")).ToArray()
-                );
+            File.WriteAllLines(filePath, lines.Where(l => !l.Trim().StartsWith(@"""Scc")).ToArray(), Encoding.UTF8);
             return Environment.TickCount - ticks;
         }
 


### PR DESCRIPTION
With multiple versions of Visual Studio loaded, solutions use the Visual Studio Version Selector to load.  If `.sln` files are not encoded as UTF-8, they will not open (though they can still be loaded manually from inside Visual Studio 2010.)  We ran into this issue when using vault2git, but luckily it was just a couple lines that needed to be changed.

Here is a post explaining a little further: http://www.richardfawcett.net/2011/02/18/visual-studio-2010-solution-wont-open-from-explorer/

P.S. Thanks for writing this awesome tool!
