### PR TITLE
UTF8 encoded vault checkin-notes trigger error commit message does not conform to UTF-8

### DIFF
--- a/Vault2GitCLI/Program.cs
+++ b/Vault2GitCLI/Program.cs
@@ -96,6 +96,7 @@ namespace Vault2Git.CLI
         static void Main(string[] args)
         {
             Console.WriteLine("Vault2Git -- converting history from Vault repositories to Git");
+            System.Console.InputEncoding = System.Text.Encoding.UTF8;
 
             //get configuration for branches
             var paths = ConfigurationManager.AppSettings["Convertor.Paths"];


### PR DESCRIPTION
If you have non ascii characters in you check-in notes in Vault, these will not be saved with the correct encoding in Git, and also will trigger error message :

```
Commit message does not conform to UTF-8.
You may want to amend it after fixing the message, or set the config
  variable i18n.commitencoding to the encoding your project uses.
```

Setting the console encoding to UTF-8 solved the problem for me, but maybe there is a better place to put it in the code.
