### PR TITLE
Fix date to allow commits to vault after 2020 to be transferred

### DIFF
--- a/Vault2GitLib/Processor.cs
+++ b/Vault2GitLib/Processor.cs
@@ -293,7 +293,7 @@ namespace Vault2Git.Lib
             foreach (var i in ServerOperations.ProcessCommandVersionHistory(repoPath,
                                                                             1,
                                                                             VaultDateTime.Parse("2000-01-01"),
-                                                                            VaultDateTime.Parse("2020-01-01"),
+                                                                            VaultDateTime.Parse("2120-01-01"),
                                                                             0))
                 info.Add(i.Version, new VaultVersionInfo()
                                         {


### PR DESCRIPTION
The existing code stops at Jan 1, 2020.  This change will keep this project running until 2120.

It would be better to make the date dependent on current date, but it is a riskier change and not worth it in my opinion.